### PR TITLE
CI: Change publish token to secrets.GITHUB_TOKEN

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -40,4 +40,4 @@ jobs:
           ./build/klaabu-linux-amd64.sha512
           ./build/klaabu-darwin-amd64.sha512
       env:
-        GITHUB_TOKEN: ${{ secrets.PUBLISH_TOKEN}}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Changing the token to publish artifacts from `PUBLISH_TOKEN` to `GITHUB_TOKEN`: https://docs.github.com/en/actions/reference/authentication-in-a-workflow