### PR TITLE
Change ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,21 +3,26 @@
 Klaabu is an IP network documenting tool, usually referred to as an IPAM (IP Address Management) tool, with a very strong focus on simplicity, convenience, and operating in Cloud-Native environments.
 
 ## Preface
+
 A big THANKS to **Taras Burko**, for mentoring me, and for all your time & effort in writing this program with me.
 
 A big THANKS to **Taavi Tuisk** for mentoring & helping me these past years.
 
 ## Why invent something new?
+
 There are a ton of different IPAM tools available out there, but with Klaabu you don’t have to <i>host</i> and <i>maintain</i> yet another tool. NetBox, for instance, is a great tool, but in case NetBox is your source-of-truth, you will need to have some sort of an SLA, strong observability, DR plan, and more.
 Klaabu tries to solve this unnecessary TOIL by using a file-based schema that you can store in Git and a powerful `validate` function to make sure your schema is in the right state. The validate function can be used in your CI pipeline, or standalone, to make sure you don’t have duplicated, overlapping CIDRs, or some other schema mistakes. The combination of storing your schema in Git and the validate function offers exactly the kind of workflow you are already used to, with code reviews, audit trails, and more.
 
 ### Why another markup language?
+
 The first couple of iterations of the Klaabu program were using a YAML-based schema. However, after using Klaabu in a live environment (with 100 VPCs, ~500 subnets, BGP ASNs, and more) we decided that this is not the right format. Using a YAML-based schema in such an environment will result in hundreds of lines, which becomes very hard to read. We believe that the ‘Klaabu Markup Language’ (`kml`) is much easier and more convenient to the user.
 
 ### Terraform
+
 Apart from some other powerful (CLI) functions, Klaabu offers the `export-terraform` function which exports your schema to a Terraform supported module. In turn, you can import this module from any other Terraform module and lookup the CIDRs, attributes, or labels. Having a single source-of-truth that also works natively with Terraform is very convenient and will simplify the usage of your VPC, Subnet, SG, and other Terraform modules a lot.
 
 ## Installation
+
 With GO installed:
 
 ```bash
@@ -39,6 +44,7 @@ make build
 Last but not least, you can also just download the binary directly from the release page.
 
 ## CLI usage
+
 ```
 Usage: klaabu <command> [args]
 ```
@@ -54,6 +60,7 @@ At the moment the Klaabu CLI supports the following commands:
 * `export-terraform`: exports your schema to a valid Terraform module; your schema is stored in a file with the `tf.json` notation, which is a valid input module for Terraform.
 
 ### Examples
+
 The examples assume your schema lives in the current working directory / you have an environment variable set pointing to the location of your schema.
 
 ```bash
@@ -67,6 +74,7 @@ klaabu find -label vpc=foobar,env=production
 ```
 
 ## Workflow
+
 - Create a new private repository and store your `schema.kml` in there
 - Use your IDE to add a new CIDR to your schema
 - Run `klaabu fmt` to produce configuration files that conform to the imposed style
@@ -74,4 +82,5 @@ klaabu find -label vpc=foobar,env=production
 - Follow your personal/company’s process for committing and merging your changes. You probably want to follow the traditional code review process with a CI pipeline that also uses the validate function.
 
 ## Contributing
+
 Check out the [CONTRIBUTING](./CONTRIBUTING.md/) guide if you want to contribute.

--- a/README.md
+++ b/README.md
@@ -2,12 +2,6 @@
 
 Klaabu is an IP network documenting tool, usually referred to as an IPAM (IP Address Management) tool, with a very strong focus on simplicity, convenience, and operating in Cloud-Native environments.
 
-## Preface
-
-A big THANKS to **Taras Burko**, for mentoring me, and for all your time & effort in writing this program with me.
-
-A big THANKS to **Taavi Tuisk** for mentoring & helping me these past years.
-
 ## Why invent something new?
 
 There are a ton of different IPAM tools available out there, but with Klaabu you don’t have to <i>host</i> and <i>maintain</i> yet another tool. NetBox, for instance, is a great tool, but in case NetBox is your source-of-truth, you will need to have some sort of an SLA, strong observability, DR plan, and more.
@@ -26,13 +20,13 @@ Apart from some other powerful (CLI) functions, Klaabu offers the `export-terraf
 With GO installed:
 
 ```bash
-go get github.com/erikkn/klaabu
+go get github.com/transferwise/klaabu
 ```
 
 Alternatively, you can also import the package directly:
 
 ```bash
-import “github.com/erikkn/klaabu”
+import “github.com/transferwise/klaabu”
 ```
 
 In case you want to build the package yourself
@@ -84,3 +78,10 @@ klaabu find -label vpc=foobar,env=production
 ## Contributing
 
 Check out the [CONTRIBUTING](./CONTRIBUTING.md/) guide if you want to contribute.
+
+
+## Acknowledgements
+
+A big THANKS to **Taras Burko**, for mentoring me, and for all your time & effort in writing this program with me.
+
+A big THANKS to **Taavi Tuisk** for mentoring & helping me these past years.

--- a/cli/find.go
+++ b/cli/find.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/erikkn/klaabu/klaabu"
+	"github.com/transferwise/klaabu/klaabu"
 )
 
 // The purpose of the 'find' command is more to 'explore' the schema and searching for something in a broad way. 'GET', however, is used if you already know what you need to lookup and do a specific search.

--- a/cli/fmt.go
+++ b/cli/fmt.go
@@ -8,7 +8,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/erikkn/klaabu/klaabu"
+	"github.com/transferwise/klaabu/klaabu"
 )
 
 func fmtCommand() {

--- a/cli/get.go
+++ b/cli/get.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"flag"
-	"github.com/erikkn/klaabu/klaabu"
 	"log"
 	"os"
+
+	"github.com/transferwise/klaabu/klaabu"
 )
 
 func getCommand() {

--- a/cli/init.go
+++ b/cli/init.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/erikkn/klaabu/klaabu"
+	"github.com/transferwise/klaabu/klaabu"
 )
 
 func initCommand() {

--- a/cli/space.go
+++ b/cli/space.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"flag"
-	"github.com/erikkn/klaabu/klaabu"
-	"github.com/erikkn/klaabu/klaabu/iputil"
 	"log"
 	"os"
 	"sort"
+
+	"github.com/transferwise/klaabu/klaabu"
+	"github.com/transferwise/klaabu/klaabu/iputil"
 )
 
 func spaceCommand() {

--- a/cli/terraform.go
+++ b/cli/terraform.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/erikkn/klaabu/klaabu"
-	"github.com/erikkn/klaabu/klaabu/terraform"
+	"github.com/transferwise/klaabu/klaabu"
+	"github.com/transferwise/klaabu/klaabu/terraform"
 )
 
 func exportTerraformCommand() {

--- a/cli/validate.go
+++ b/cli/validate.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/erikkn/klaabu/klaabu"
+	"github.com/transferwise/klaabu/klaabu"
 )
 
 func validateCommand() {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/erikkn/klaabu
+module github.com/transferwise/klaabu
 
 go 1.15

--- a/klaabu/kml.go
+++ b/klaabu/kml.go
@@ -3,9 +3,10 @@ package klaabu
 import (
 	"errors"
 	"fmt"
-	"github.com/erikkn/klaabu/klaabu/kml"
 	"io"
 	"os"
+
+	"github.com/transferwise/klaabu/klaabu/kml"
 )
 
 const (

--- a/klaabu/kml/marshal.go
+++ b/klaabu/kml/marshal.go
@@ -1,10 +1,11 @@
 package kml
 
 import (
-	"github.com/erikkn/klaabu/klaabu/iputil"
 	"io"
 	"sort"
 	"strings"
+
+	"github.com/transferwise/klaabu/klaabu/iputil"
 )
 
 type ColumnWidths struct {

--- a/klaabu/prefix.go
+++ b/klaabu/prefix.go
@@ -2,8 +2,9 @@ package klaabu
 
 import (
 	"fmt"
-	"github.com/erikkn/klaabu/klaabu/iputil"
 	"sort"
+
+	"github.com/transferwise/klaabu/klaabu/iputil"
 )
 
 // Cidr represents a single CIDR notation.

--- a/klaabu/terraform/terraform.go
+++ b/klaabu/terraform/terraform.go
@@ -3,7 +3,7 @@ package terraform
 import (
 	"encoding/json"
 
-	"github.com/erikkn/klaabu/klaabu"
+	"github.com/transferwise/klaabu/klaabu"
 )
 
 type module struct {

--- a/klaabu/validate.go
+++ b/klaabu/validate.go
@@ -2,8 +2,9 @@ package klaabu
 
 import (
 	"fmt"
-	"github.com/erikkn/klaabu/klaabu/iputil"
 	"net"
+
+	"github.com/transferwise/klaabu/klaabu/iputil"
 )
 
 // MinMaxIP lalala.


### PR DESCRIPTION
Former maintainer of this tool has left the company. Ownership was transferred to the `transferwise` org, this PR updates the package names to reflect these changes. This is necessary to make `go get` work with this package.